### PR TITLE
[Feature Request] Append modification date to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ You can exclude a folder and all its subfolders in the Settings page.
 
 If you want to exclude a single file, you can add a property called `exclude_modified_update` and give it a value. Setting it to `true` or using the Checkbox property type would be the most sensible option.
 
+## Append date to history
+
+You can also append the date to an history by adding a property called `append_modified_update` and giving it `true` as a value. This is useful if you want to keep track of every time you edit a note.
+
+> [!WARNING] Removing the `append_modified_update` property from the frontmatter will remove all saved modification dates.
+
 ## "Merging changes" popup
 
 It's possible when using this plugin that you will see a message like this, however it should be a rare occurance rather than the norm:

--- a/main.ts
+++ b/main.ts
@@ -8,6 +8,7 @@ interface FrontmatterModifiedSettings {
   onlyUpdateExisting: boolean;
   timeout: number;
   excludeField: string;
+  appendToHistory: string;
 }
 
 const DEFAULT_SETTINGS: FrontmatterModifiedSettings = {
@@ -17,7 +18,8 @@ const DEFAULT_SETTINGS: FrontmatterModifiedSettings = {
   useKeyupEvents: false,
   onlyUpdateExisting: false,
   timeout: 10,
-  excludeField: 'exclude_modified_update'
+  excludeField: 'exclude_modified_update',
+  appendToHistory: 'append_modified_update'
 }
 
 export default class FrontmatterModified extends Plugin {
@@ -124,7 +126,23 @@ export default class FrontmatterModified extends Plugin {
             }
           }
           if (secondsSinceLastUpdate > 30) {
-            frontmatter[this.settings.frontmatterProperty] = now.format(this.settings.momentFormat)
+            let propValue = now.format(this.settings.momentFormat)
+
+            if (frontmatter[this.settings.appendToHistory]) {
+              if (Array.isArray(frontmatter[this.settings.frontmatterProperty])) {
+                // Append the current date to the list if it's not already there
+                if (!frontmatter[this.settings.frontmatterProperty].includes(propValue)) {
+                  frontmatter[this.settings.frontmatterProperty].push(propValue)
+                }
+              } else {
+                // Create an array with the original value and the current date
+                frontmatter[this.settings.frontmatterProperty] = frontmatter[this.settings.frontmatterProperty].includes(propValue) ?
+                  [propValue] :
+                  [frontmatter[this.settings.frontmatterProperty], propValue]
+              }
+            } else {
+              frontmatter[this.settings.frontmatterProperty] = propValue
+            }
           }
         }
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "frontmatter-modified-date",
-	"version": "1.0.4",
+	"version": "1.2.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "frontmatter-modified-date",
-			"version": "1.0.4",
+			"version": "1.2.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.6",


### PR DESCRIPTION
Hello, firstly thank you for this Obsidian plugin.

I'd like to add this feature to it; it adds the possibility of having a list of dates in the frontmatter property instead of a single date.

The goal is to have the history of the modifications of a file in the frontmatter and to be able to use it with Dataview to list the files created and modified on a given day.

Here is an example of a Dataview request to list all files changed today (2023/09/15) with this option enabled :

```dataview
TABLE WITHOUT ID
	file.link as Note,
	link(file.folder) as Folder,
	file.etags as Tags
WHERE any(nonnull(modification), (x) => dateformat(date(x), "yyyy-MM-dd") = "2023-09-15")
```
