### PR TITLE
Use CodeMirror API to handle timestamp update in special mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 	"author": "",
 	"license": "MIT",
 	"devDependencies": {
+		"@codemirror/view": "^6.38.1",
 		"@types/node": "^16.11.6",
 		"@typescript-eslint/eslint-plugin": "5.29.0",
 		"@typescript-eslint/parser": "5.29.0",

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,0 +1,53 @@
+import { EditorView, PluginValue, ViewPlugin, ViewUpdate } from '@codemirror/view';
+import { editorInfoField, TFile } from 'obsidian';
+import FrontmatterModified from 'main';
+
+/**
+ * `UserChangeListener` wrapper, should be registered through `plugin.registerEditorExtension()`
+ */
+export const userChangeListenerExtension = (plugin: FrontmatterModified) => ViewPlugin.define(view => {
+  return new UserChangeListener(plugin, view)
+})
+
+/**
+ * Watch for any explicit user change and update the timestamp when found.
+ * 
+ * Therefore, any external change and the change that happens without explicit user interaction,
+ * e.g multiple editors holding the same note while some of them have a change made by another editor,
+ * will be ignored.
+ * 
+ * Only works if `useKeyupEvents` is set to `true`.
+ */
+class UserChangeListener implements PluginValue {
+  plugin: FrontmatterModified
+  file: TFile | null
+
+  constructor (plugin: FrontmatterModified, view: EditorView) {
+    this.plugin = plugin
+    this.file = view.state.field(editorInfoField).file
+  }
+
+  update (update: ViewUpdate) {
+    if (!this.file || !this.plugin.settings.useKeyupEvents) {
+      return
+    }
+
+    if (isUserChange(update)) {
+      this.plugin.updateFrontmatter(this.file)
+    }
+  }
+}
+
+/**
+ * Check whether the given update is resulted by user event(s)
+ */
+function isUserChange (update: ViewUpdate) {
+  // No change happens, or the change that happens because of opening another note in the same editor
+  if (!update.docChanged || update.transactions.some(tr => tr.isUserEvent('set'))) {
+    return false
+  }
+  return update.transactions.some(tr => {
+    // See https://codemirror.net/docs/ref/#state.Transaction^userEvent
+    return tr.isUserEvent('input') || tr.isUserEvent('delete') || tr.isUserEvent('move')
+  })
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -139,7 +139,7 @@ export default class FrontmatterModified extends Plugin {
         // as a preventative measure against a race condition where two devices have the same note open
         // and are both syncing and updating each other.
         // Are we appending to an array of entries?
-        if (secondsSinceLastUpdate > 3) {
+        if (secondsSinceLastUpdate > 30) {
           type StringOrInteger = string | number
           let newEntry: StringOrInteger | StringOrInteger[] = this.formatFrontmatterDate(now)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { Plugin, TFile, moment } from 'obsidian'
 import { DEFAULT_SETTINGS, FrontmatterModifiedSettings, FrontmatterModifiedSettingTab } from './settings'
+import { userChangeListenerExtension } from './editor'
 
 export default class FrontmatterModified extends Plugin {
   settings: FrontmatterModifiedSettings
@@ -7,6 +8,9 @@ export default class FrontmatterModified extends Plugin {
 
   async onload () {
     await this.loadSettings()
+
+    // The extension will run in the special mode only.
+    this.registerEditorExtension(userChangeListenerExtension(this))
 
     if (!this.settings.useKeyupEvents) {
       /*
@@ -27,6 +31,8 @@ export default class FrontmatterModified extends Plugin {
         }
       }))
     } else if (this.settings.useKeyupEvents) {
+      // Do nothing, replaced by 'userChangeListenerExtension'
+
       /*
        * This is a special mode for users who can't rely on Obsidian detecting file changes.
        * Both of these built-in events fire when a file is externally modified:
@@ -44,6 +50,7 @@ export default class FrontmatterModified extends Plugin {
        * here, please let me know! It works just fine but perhaps there's a better way.
        */
 
+      /*
       // Watch for typing events
       this.registerDomEvent(document, 'input', (event: InputEvent) => {
         // Check to see if the inputted key is a single, visible Unicode character.
@@ -55,6 +62,7 @@ export default class FrontmatterModified extends Plugin {
       })
       // Watch for clipboard paste
       this.registerDomEvent(document, 'paste', (event: ClipboardEvent) => { this.handleTypingEvent(event) })
+      */
     }
 
     this.addSettingTab(new FrontmatterModifiedSettingTab(this.app, this))
@@ -131,7 +139,7 @@ export default class FrontmatterModified extends Plugin {
         // as a preventative measure against a race condition where two devices have the same note open
         // and are both syncing and updating each other.
         // Are we appending to an array of entries?
-        if (secondsSinceLastUpdate > 30) {
+        if (secondsSinceLastUpdate > 3) {
           type StringOrInteger = string | number
           let newEntry: StringOrInteger | StringOrInteger[] = this.formatFrontmatterDate(now)
 


### PR DESCRIPTION
It's a way better than the already employed one, as it only listens to the editor events directly instead of listening to the whole document.