### PR TITLE
Update created date on empty field and improved exclude folders settings

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -121,8 +121,8 @@ export default class FrontmatterModified extends Plugin {
             // Update the modified date field
             frontmatter[this.settings.frontmatterProperty] = newEntry
 
-            // Create a created date field if requested
-            if (!this.settings.onlyUpdateExisting && this.settings.createdDateProperty && !frontmatter[this.settings.createdDateProperty]) {
+            // Create a created date field if requested or update created date field if date is null
+            if (!this.settings.onlyUpdateExisting && this.settings.createdDateProperty && !frontmatter[this.settings.createdDateProperty] || frontmatter[this.settings.createdDateProperty] === null) {
               frontmatter[this.settings.createdDateProperty] = this.formatFrontmatterDate(moment(file.stat.ctime || now))
             }
           })

--- a/src/suggesterFuzzy.ts
+++ b/src/suggesterFuzzy.ts
@@ -1,0 +1,42 @@
+import { FuzzySuggestModal } from "obsidian";
+
+export class LabeledSuggestModal extends FuzzySuggestModal<string> {
+    private promise: Promise<any>;
+    private resolvedPromise: (value: any) => void;
+
+    public static open(arrayToReturn: any[], stringArrayToDisplay: string[], placeholderString?: string) {
+        // console.debug("open(",arrayToReturn,",",stringArrayToDisplay,",",placeholderString,") was called.");
+        const modalToSpawn = new LabeledSuggestModal(arrayToReturn, stringArrayToDisplay, placeholderString);
+        return modalToSpawn.promise;
+    }
+
+    constructor(private arrayToReturn: any[], private stringArrayToDisplay: string[], private placeholderString?: string) {
+        // console.debug("constructor(",arrayToReturn,",",stringArrayToDisplay,",",placeholderString,") was called.");
+        super(app);
+        this.promise = new Promise<any>(
+            (resolve) => (this.resolvedPromise = resolve)
+        );
+        
+        if (placeholderString != undefined){
+            this.setPlaceholder(placeholderString);
+        }
+        
+        this.open();
+    }
+    
+   getItems(): any[] {
+        // console.debug("getItems() was called.");
+        return this.arrayToReturn;
+    }
+
+    getItemText(currentObject: any): string {
+        // console.debug("getItemText(",currentObject, ") was called.");
+        return this.stringArrayToDisplay[this.arrayToReturn.indexOf(currentObject)];
+    }
+
+    onChooseItem(chosenObject: any, evt: MouseEvent | KeyboardEvent): void {
+        // console.debug("onChooseItem(",chosenObject,") was called.");
+        this.resolvedPromise(chosenObject);
+    }
+
+}


### PR DESCRIPTION
In almost all my templates I include both the fields `created:` and `modified:` which are undefined when the file is created from the template. Like this...

```
---
created:
modified:
---
```

In this situation the modified date is updated correctly, but the created date field is never updated. This is easily corrected by adding to the end of the conditional test line ` || frontmatter[this.settings.createdDateProperty] === null` I have been doing this manually on every plugin update but that is easy to forget to do until I notice the created field is empty in all my newly created notes after a plugin update. This addition solves that issue for me.

I also removed the exclude folders text area component in the settings and replaced it with a folder selector modal that removes the need for the user to manually enter the folder name making it much less prone to typing errors. Here is a picture showing what this changes in more detail...

<img width="1100" height="228" alt="ExcludeFolders" src="https://github.com/user-attachments/assets/e01b0316-65d9-43bf-b297-081f89bdbd57" />

Thank you for the great plugin, William.
